### PR TITLE
fix/math#12 affinematrix conversions

### DIFF
--- a/src/apps/tests/tests/CMakeLists.txt
+++ b/src/apps/tests/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TARGET_NAME ${_lower_project_name}_tests)
 
 set(${TARGET_NAME}_HEADERS
     catch.hpp
+    CustomCatchMatchers.h
     detection.h
     operation_detectors.h
 )

--- a/src/apps/tests/tests/CMakeLists.txt
+++ b/src/apps/tests/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(${TARGET_NAME}_SOURCES
     Constexpr_tests.cpp
     Homogeneous_tests.cpp
     Interpolation_tests.cpp
+    LinearMatrix_tests.cpp
     Matrix.cpp
     Noexcept_tests.cpp
     Polynomial.cpp

--- a/src/apps/tests/tests/CustomCatchMatchers.h
+++ b/src/apps/tests/tests/CustomCatchMatchers.h
@@ -9,9 +9,7 @@ class MatrixApprox : public Catch::MatcherBase<T_matrix>
     using tolerance_type = typename T_matrix::value_type;
 
 public:
-    MatrixApprox(
-            T_matrix aExpected,
-            tolerance_type aTolerance = ) :
+    MatrixApprox(T_matrix aExpected, tolerance_type aTolerance) :
         mExpected{std::move(aExpected)},
         mTolerance{std::move(aTolerance)}
     {}
@@ -40,7 +38,7 @@ private:
 template <class T_matrix>
 MatrixApprox<T_matrix> Approximates(
         T_matrix && aExpected,
-        typename T_matrix::value_type aTolerance = std::numeric_limits<T_matrix::value_type>::epsilon())
+        typename T_matrix::value_type aTolerance = std::numeric_limits<typename T_matrix::value_type>::epsilon())
 {
     return MatrixApprox(std::forward<T_matrix>(aExpected),
                         aTolerance);

--- a/src/apps/tests/tests/CustomCatchMatchers.h
+++ b/src/apps/tests/tests/CustomCatchMatchers.h
@@ -1,0 +1,47 @@
+#include "catch.hpp"
+
+#include <sstream>
+
+
+template <class T_matrix>
+class MatrixApprox : public Catch::MatcherBase<T_matrix>
+{
+    using tolerance_type = typename T_matrix::value_type;
+
+public:
+    MatrixApprox(
+            T_matrix aExpected,
+            tolerance_type aTolerance = ) :
+        mExpected{std::move(aExpected)},
+        mTolerance{std::move(aTolerance)}
+    {}
+
+    // Performs the test for this matcher
+    bool match(const T_matrix & aMatrix) const override
+    {
+        return aMatrix.equalsWithinTolerance(mExpected, mTolerance);
+    }
+
+    // Produces a string describing what this matcher does. It should
+    std::string describe() const override
+    {
+        std::ostringstream ss;
+        ss << "equals " << mExpected << " within a tolerance of " << mTolerance;
+        return ss.str();
+    }
+
+private:
+    T_matrix mExpected;
+    typename T_matrix::value_type mTolerance;
+};
+
+
+// The builder function
+template <class T_matrix>
+MatrixApprox<T_matrix> Approximates(
+        T_matrix && aExpected,
+        typename T_matrix::value_type aTolerance = std::numeric_limits<T_matrix::value_type>::epsilon())
+{
+    return MatrixApprox(std::forward<T_matrix>(aExpected),
+                        aTolerance);
+}

--- a/src/apps/tests/tests/Homogeneous_tests.cpp
+++ b/src/apps/tests/tests/Homogeneous_tests.cpp
@@ -233,13 +233,33 @@ SCENARIO("Affine matrices conversions")
         });
     }
 
-    // Note: this very case with conversion to AffineMatrix<2> is a very good reason
-    // for making the MatrixBase(Element ...) ctor explicit: otherwise the
-    // ctor for AffineMatrix<2> taking a Matrix<1, 1> becomes available, since
-    // MatrixBase(Element ...) would be availabe to attempt an implicit conversion
-    // from Matrix<2, 2> to the single Element of a Matrix<1, 1>. 
-    REQUIRE_FALSE(is_detected_v<is_staticcastable_t, Matrix<2, 2>, AffineMatrix<2>>);
-    REQUIRE_FALSE(is_detected_v<is_staticcastable_t, Matrix<3, 3>, AffineMatrix<3>>);
+    THEN("Plain matrices cannot be cast to Affine Matrices of equal dimension")
+    {
+        // Note: this very case with conversion to AffineMatrix<2> is a very good reason
+        // for making the MatrixBase(Element ...) ctor explicit: otherwise the
+        // ctor for AffineMatrix<2> taking a Matrix<1, 1> becomes available, since
+        // MatrixBase(Element ...) would be availabe to attempt an implicit conversion
+        // from Matrix<2, 2> to the single Element of a Matrix<1, 1>. 
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, Matrix<2, 2>, AffineMatrix<2>>);
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, Matrix<3, 3>, AffineMatrix<3>>);
+    }
+
+    THEN("Affine Matrices of dimension N cannot be cast to Affine Matrices of adjacent dimensions.")
+    {
+        // Note: these cases from N to N+1 is a rationale for making explicit 
+        // the ctor taking a Matrix<N, N>: an AffineMatrix<N> is-a Matrix<N,N>,
+        // which would then be implicitly convertible to AffineMatrix<N+1>.
+        CHECK_FALSE(std::is_convertible_v<AffineMatrix<2>, AffineMatrix<3>>);
+        CHECK_FALSE(std::is_convertible_v<AffineMatrix<3>, AffineMatrix<4>>);
+
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<2>, AffineMatrix<3>>);
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<3>, AffineMatrix<4>>);
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<2>, AffineMatrix<4>>);
+
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<3>, AffineMatrix<2>>);
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<4>, AffineMatrix<3>>);
+        CHECK_FALSE(is_detected_v<is_staticcastable_t, AffineMatrix<4>, AffineMatrix<2>>);
+    } 
 }
 
 SCENARIO("Affine matrices available operations")

--- a/src/apps/tests/tests/Homogeneous_tests.cpp
+++ b/src/apps/tests/tests/Homogeneous_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <math/Angle.h>
 #include <math/Homogeneous.h>
+#include <math/LinearMatrix.h>
 #include <math/Transformations.h>
 
 
@@ -221,7 +222,7 @@ SCENARIO("Affine matrices conversions")
         REQUIRE(is_detected_v<is_staticcastable_t, AffineMatrix<3>, Matrix<3, 3>>);
 
         AffineMatrix<2> affine{
-            Matrix<1, 1>{1.},
+            LinearMatrix<1, 1>{1.},
             Vec<1>{3.}
         };
 
@@ -266,10 +267,18 @@ SCENARIO("Affine matrices available operations")
 {
     using Affine3 = AffineMatrix<3>;
     using Affine4 = AffineMatrix<4>;
-    using Matrix4x4 = Matrix<4, 4>;
+    using Linear2 = LinearMatrix<2, 2>;
+    using Linear3 = LinearMatrix<3, 3>;
+    using Linear4 = LinearMatrix<4, 4>;
+    using Linear5 = LinearMatrix<5, 5>;
+    using Matrix2x2 = Matrix<2, 2>;
+    using Matrix3x3 = Matrix<3, 3>;
     using Matrix3x4 = Matrix<3, 4>;
+    using Matrix4x4 = Matrix<4, 4>;
+    using Matrix5x5 = Matrix<5, 5>;
 
-    THEN("Affine matrices can be multiplied with 'plain' matrices of matching dimensions.")
+    THEN("Affine matrices can be multiplied with 'plain' matrices of matching dimensions,"
+         " resulting in plain matrices.")
     {
         // Affine x Matrix -> Matrix
         REQUIRE(is_detected_v<is_multiplicative_t, Affine4, Matrix4x4>);
@@ -284,6 +293,28 @@ SCENARIO("Affine matrices available operations")
         THEN("Multiplication is not available if dimensions don't match")
         {
             REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Affine4, Matrix3x4>);
+            // Available for Linear, not for plain of dimensions N-1
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Affine4, Matrix3x3>);
+        }
+    }
+
+    THEN("Affine matrices of N dimension can be multiplied with Linear matrices of N-1 dimensions,"
+         " resulting in Affine matrices of N dimension.")
+    {
+        // Affine<N> x LinearMatrix<N-1> -> AffineMatrix<N>
+        REQUIRE(is_detected_v<is_multiplicative_t, Affine4, Linear3>);
+        REQUIRE(std::is_same_v<decltype(std::declval<Affine4>() * std::declval<Linear3>()),
+                               Affine4>);
+
+        THEN("They can be compound multiplied.")
+        {
+            REQUIRE(is_detected_v<is_multiplicative_assignable_t, Affine4, Linear3>);
+        }
+
+        THEN("Multiplication is not available for lower or higher dimensions")
+        {
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Affine4, Linear2>);
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Affine4, Linear5>);
         }
     }
 
@@ -302,6 +333,28 @@ SCENARIO("Affine matrices available operations")
         {
             REQUIRE(is_detected_v<is_multiplicative_assignable_t, Matrix4x4, Affine4>);
             REQUIRE(is_detected_v<is_multiplicative_assignable_t, Matrix3x4, Affine4>);
+            // Available for Linear, not for plain of dimensions N-1
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Matrix3x3, Affine4>);
+        }
+    }
+
+    THEN("Linear matrices of N-1 dimension can be multiplied with Affine matrices of N dimension,"
+         " resulting in Affine matrices of N dimension.")
+    {
+        // LinearMatrix<N-1> x Affine<N> -> AffineMatrix<N>
+        REQUIRE(is_detected_v<is_multiplicative_t, Linear3, Affine4>);
+        REQUIRE(std::is_same_v<decltype(std::declval<Linear3>() * std::declval<Affine4>()),
+                               Affine4>);
+
+        THEN("They cannot be compound multiplied into the Linear matrix.")
+        {
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, Linear3, Affine4>);
+        }
+
+        THEN("Multiplication is not available for lower or higher dimensions")
+        {
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Linear2, Affine4>);
+            REQUIRE_FALSE(is_detected_v<is_multiplicative_t, Linear5, Affine4>);
         }
     }
 

--- a/src/apps/tests/tests/Homogeneous_tests.cpp
+++ b/src/apps/tests/tests/Homogeneous_tests.cpp
@@ -269,13 +269,10 @@ SCENARIO("Affine matrices available operations")
     using Affine4 = AffineMatrix<4>;
     using Linear2 = LinearMatrix<2, 2>;
     using Linear3 = LinearMatrix<3, 3>;
-    using Linear4 = LinearMatrix<4, 4>;
     using Linear5 = LinearMatrix<5, 5>;
-    using Matrix2x2 = Matrix<2, 2>;
     using Matrix3x3 = Matrix<3, 3>;
     using Matrix3x4 = Matrix<3, 4>;
     using Matrix4x4 = Matrix<4, 4>;
-    using Matrix5x5 = Matrix<5, 5>;
 
     THEN("Affine matrices can be multiplied with 'plain' matrices of matching dimensions,"
          " resulting in plain matrices.")

--- a/src/apps/tests/tests/LinearMatrix_tests.cpp
+++ b/src/apps/tests/tests/LinearMatrix_tests.cpp
@@ -10,15 +10,48 @@ using namespace ad;
 using namespace ad::math;
 
 
+SCENARIO("Linear matrix construction")
+{
+    THEN("An Linear matrix can be constructed by specifying each element.")
+    {
+        LinearMatrix<2, 2> linear{
+            1.f, 2.f,
+            3.f, 4.f
+        };
+
+        double expected = 0.f;
+        for (auto element : linear)
+        {
+            REQUIRE(element == ++expected);
+        }
+    }
+    THEN("An identity Linear matrix can be constructed.")
+    {
+        LinearMatrix<4, 4> identity = LinearMatrix<4, 4>::Identity();
+        REQUIRE(identity == Matrix<4, 4>::Identity());
+    }
+}
+
+
 SCENARIO("LinearMatrix available operations")
 {
     using Linear4 = LinearMatrix<4, 4>;
+
+    THEN("A 'plain' matrix cannot be converted to a Linear matrix")
+    {
+        REQUIRE_FALSE(is_detected_v<is_staticcastable_t, Matrix<4, 4>, Linear4>);
+    }
+
+    THEN("A Linar matrix is implicitly convertible to a 'plain' matrix")
+    {
+        REQUIRE(std::is_convertible_v<Linear4, Matrix<4, 4>>);
+    }
+
     THEN("Two square matrices of same dimension can be compound multiplied")
     {
         REQUIRE(is_detected_v<is_multiplicative_assignable_t, Linear4, Linear4>);
         REQUIRE(std::is_same_v<decltype(std::declval<Linear4>() * std::declval<Linear4>()),
                                Linear4>);
-
     }
     THEN("Two square matrices of different dimension cannot be compound multiplied")
     {
@@ -31,7 +64,6 @@ SCENARIO("LinearMatrix available operations")
     }
     THEN("Two non-square matrices of same dimension cannot be compound multiplied")
     {
-        // Only disabled by static assert
-        //REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, LinearMatrix<3,4>, LinearMatrix<3, 4>>);
+        REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, LinearMatrix<3,4>, LinearMatrix<3, 4>>);
     }
 }

--- a/src/apps/tests/tests/LinearMatrix_tests.cpp
+++ b/src/apps/tests/tests/LinearMatrix_tests.cpp
@@ -1,0 +1,37 @@
+#include "catch.hpp"
+
+#include "detection.h"
+#include "operation_detectors.h"
+
+#include <math/LinearMatrix.h>
+
+
+using namespace ad;
+using namespace ad::math;
+
+
+SCENARIO("LinearMatrix available operations")
+{
+    using Linear4 = LinearMatrix<4, 4>;
+    THEN("Two square matrices of same dimension can be compound multiplied")
+    {
+        REQUIRE(is_detected_v<is_multiplicative_assignable_t, Linear4, Linear4>);
+        REQUIRE(std::is_same_v<decltype(std::declval<Linear4>() * std::declval<Linear4>()),
+                               Linear4>);
+
+    }
+    THEN("Two square matrices of different dimension cannot be compound multiplied")
+    {
+        REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, LinearMatrix<3,3>, LinearMatrix<4, 4>>);
+    }
+    THEN("Two multipliable matrices of different size cannot be compound multiplied")
+    {
+        REQUIRE(is_detected_v<is_multiplicative_t, LinearMatrix<3,3>, LinearMatrix<3, 4>>);
+        REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, LinearMatrix<3,3>, LinearMatrix<3, 4>>);
+    }
+    THEN("Two non-square matrices of same dimension cannot be compound multiplied")
+    {
+        // Only disabled by static assert
+        //REQUIRE_FALSE(is_detected_v<is_multiplicative_assignable_t, LinearMatrix<3,4>, LinearMatrix<3, 4>>);
+    }
+}

--- a/src/apps/tests/tests/Transformations_tests.cpp
+++ b/src/apps/tests/tests/Transformations_tests.cpp
@@ -1,5 +1,7 @@
 #include "catch.hpp"
 
+#include "CustomCatchMatchers.h"
+
 #include <math/Base.h>
 #include <math/Constants.h>
 #include <math/Homogeneous.h>
@@ -69,6 +71,34 @@ SCENARIO("2D rotations")
 
                 APPROX_EQUAL(a * rotation, (Vec<2>{ 2.0,  0.5}));
                 APPROX_EQUAL(b * rotation, (Vec<2>{-2.0, -0.5}));
+            }
+        }
+    }
+
+    GIVEN("Homogeneous 2D vectors and positions")
+    {
+        using namespace homogeneous;
+        Vec<3> i = makeVec<3>(1., 0.);
+        Vec<3> j = makeVec<3>(0., 1.);
+
+        Position<3> a = makePosition<3>(1., 0.);
+        Position<3> b = makePosition<3>(0., 1.);
+
+        GIVEN("A center of rotation and associated -180° rotation")
+        {
+            Position<2> center{1., 0.};
+            AffineMatrix<3> rotation = trans2d::rotateAbout(-Degree<double>(180), center);
+
+            THEN("The vectors are rotated as with a rotation from the origin")
+            {
+                CHECK_THAT(i * rotation, Approximates(Vec<3>{-1.,  0., 0.}));
+                CHECK_THAT(j * rotation, Approximates(Vec<3>{ 0., -1., 0.}));
+            }
+
+            THEN("The positions are rotated about the center of rotation")
+            {
+                CHECK_THAT(a * rotation, Approximates(Position<3>{ 1.,  0., 1.}));
+                CHECK_THAT(b * rotation, Approximates(Position<3>{ 2., -1., 1.}));
             }
         }
     }

--- a/src/libs/math/math/CMakeLists.txt
+++ b/src/libs/math/math/CMakeLists.txt
@@ -12,6 +12,7 @@ set(${TARGET_NAME}_HEADERS
     Homogeneous.h
     Homogeneous-impl.h
     Interpolation.h
+    LinearMatrix.h
     Matrix.h
     Matrix-impl.h
     MatrixBase.h

--- a/src/libs/math/math/Homogeneous-impl.h
+++ b/src/libs/math/math/Homogeneous-impl.h
@@ -35,7 +35,7 @@ namespace math {
 
 
 template <TMP>
-constexpr AffineMatrix<TMA>::AffineMatrix(const Matrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
+constexpr AffineMatrix<TMA>::AffineMatrix(const LinearMatrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
                                           const Vec<N_dimension-1, T_number> & aAffine) noexcept(should_noexcept) :
         base_type{typename base_type::UninitializedTag{}}
 {
@@ -60,7 +60,7 @@ constexpr AffineMatrix<TMA>::AffineMatrix(typename base_type::UninitializedTag) 
 template <TMP>
 constexpr AffineMatrix<TMA> AffineMatrix<TMA>::Identity() noexcept(should_noexcept)
 {
-    return AffineMatrix{Matrix<N_dimension-1, N_dimension-1, T_number>::Identity()};
+    return AffineMatrix{LinearMatrix<N_dimension-1, N_dimension-1, T_number>::Identity()};
 }
 
 

--- a/src/libs/math/math/Homogeneous.h
+++ b/src/libs/math/math/Homogeneous.h
@@ -42,11 +42,9 @@ class AffineMatrix : public Matrix<N_dimension, N_dimension, T_number>
     // accepting an explicit list of elements.
 
 public:
-    /// \note Made implicit so linear matrices can be multiplied with/assigned to affines matrices
-    /// (with corresponding dimension+1).
-    /*implicit*/ constexpr AffineMatrix(const Matrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
-                                        const Vec<N_dimension-1, T_number> & aAffine =
-                                            Vec<N_dimension-1, T_number>::Zero())
+    explicit constexpr AffineMatrix(const Matrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
+                                    const Vec<N_dimension-1, T_number> & aAffine =
+                                        Vec<N_dimension-1, T_number>::Zero())
         noexcept(should_noexcept);
 
     // Implementer note:

--- a/src/libs/math/math/Homogeneous.h
+++ b/src/libs/math/math/Homogeneous.h
@@ -2,6 +2,7 @@
 
 
 #include "commons.h"
+#include "LinearMatrix.h"
 #include "Matrix.h"
 #include "Vector.h"
 
@@ -42,9 +43,9 @@ class AffineMatrix : public Matrix<N_dimension, N_dimension, T_number>
     // accepting an explicit list of elements.
 
 public:
-    explicit constexpr AffineMatrix(const Matrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
-                                    const Vec<N_dimension-1, T_number> & aAffine =
-                                        Vec<N_dimension-1, T_number>::Zero())
+    /*implicit*/ constexpr AffineMatrix(const LinearMatrix<N_dimension-1, N_dimension-1, T_number> & aLinear,
+                                        const Vec<N_dimension-1, T_number> & aAffine =
+                                            Vec<N_dimension-1, T_number>::Zero())
         noexcept(should_noexcept);
 
     // Implementer note:

--- a/src/libs/math/math/LinearMatrix.h
+++ b/src/libs/math/math/LinearMatrix.h
@@ -29,6 +29,16 @@ class LinearMatrix : public ::ad::math::Matrix<TMA>
 public:
     template<class T>
     using derived_type = LinearMatrix<N_rows, N_cols, T>;
+
+    static constexpr LinearMatrix Identity() noexcept(should_noexcept);
+
+
+private:
+    // Even though the conversion ctor is explicit and private
+    // it is detected via is_staticcastable_t. Adding a dummy tag fixes that.
+    struct Dummy{};
+    explicit LinearMatrix(base_type aOther, Dummy) : base_type{std::move(aOther)}
+    {}
 };
 
 
@@ -40,6 +50,13 @@ operator*(const LinearMatrix<TMA> &aLhs, const LinearMatrix<TMA> &aRhs)
 }
 
 
+template <TMP>
+constexpr LinearMatrix<TMA> LinearMatrix<TMA>::Identity() noexcept(should_noexcept)
+{
+    return LinearMatrix<TMA>{Matrix<TMA>::Identity(), Dummy{}};
+}
+
+ 
 #undef TMA
 #undef TMP_D
 #undef TMP

--- a/src/libs/math/math/LinearMatrix.h
+++ b/src/libs/math/math/LinearMatrix.h
@@ -1,0 +1,49 @@
+#pragma once
+
+
+#include "commons.h"
+#include "Matrix.h"
+
+
+namespace ad {
+namespace math {
+
+
+#define TMP int N_rows, int N_cols, class T_number
+#define TMP_D int N_rows, int N_cols, class T_number = real_number
+#define TMA N_rows, N_cols, T_number
+
+
+/// \brief This class should behave exactly like a Matrix of matching dimension
+/// but can be to explicitly provide more properties statically.
+///
+/// For e.g. this is usefull when it comes to multiplication with affine matrices,
+/// which can safely be done via implicit conversion.
+template <TMP_D>
+class LinearMatrix : public ::ad::math::Matrix<TMA>
+{
+    using base_type = ::ad::math::Matrix<TMA>;
+    // Ctor inheritance
+    using base_type::base_type;
+
+public:
+    template<class T>
+    using derived_type = LinearMatrix<N_rows, N_cols, T>;
+};
+
+
+template <TMP>
+constexpr LinearMatrix<TMA>
+operator*(const LinearMatrix<TMA> &aLhs, const LinearMatrix<TMA> &aRhs)
+{
+    return multiplyBase<LinearMatrix<TMA>>(aLhs, aRhs);
+}
+
+
+#undef TMA
+#undef TMP_D
+#undef TMP
+
+
+} // namespace math
+} // namespace ad

--- a/src/libs/math/math/LinearMatrix.h
+++ b/src/libs/math/math/LinearMatrix.h
@@ -25,6 +25,7 @@ class LinearMatrix : public ::ad::math::Matrix<TMA>
     using base_type = ::ad::math::Matrix<TMA>;
     // Ctor inheritance
     using base_type::base_type;
+    using base_type::should_noexcept;
 
 public:
     template<class T>

--- a/src/libs/math/math/Matrix.h
+++ b/src/libs/math/math/Matrix.h
@@ -17,11 +17,13 @@ template <int N_rows, int N_cols, class T_number=real_number>
 class Matrix : public MatrixBase<Matrix<TMP>, N_rows, N_cols, T_number>
 {
     typedef MatrixBase<Matrix<TMP>, N_rows, N_cols, T_number> base_type;
-    using base_type::base_type;
+
 protected:
     using base_type::should_noexcept;
 
 public:
+    // If not moved in the public section, VisualStudio erros on LinearMatrix compilation
+    using base_type::base_type;
 
     template<class T>
     using derived_type = Matrix<N_rows, N_cols, T>;

--- a/src/libs/math/math/Transformations-impl.h
+++ b/src/libs/math/math/Transformations-impl.h
@@ -6,7 +6,7 @@ namespace trans2d {
 
 
     template <class T_number, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle)
+    constexpr LinearMatrix<2, 2, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle)
     {
         return {
              cos(aAngle), sin(aAngle),
@@ -16,7 +16,7 @@ namespace trans2d {
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY)
+    constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY)
     {
         return {
             aFactorX,         0.,
@@ -26,7 +26,7 @@ namespace trans2d {
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> scale(const T_number aFactor, const UnitVec<2, T_number> aAxis)
+    constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactor, const UnitVec<2, T_number> aAxis)
     {
         // Some compact aliases for parameters
         const T_number & k = aFactor;
@@ -40,7 +40,7 @@ namespace trans2d {
 
 
     template <class T_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     scale(const T_number aFactorHorizontal, const T_number aFactorVertical,
           const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise)
     {
@@ -61,49 +61,49 @@ namespace trans2d {
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicOntoX()
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicOntoX()
     {
         return scale(T_number{1}, T_number{0});
     };
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicOntoY()
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicOntoY()
     {
         return scale(T_number{0}, T_number{1});
     };
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicAlong(const UnitVec<2, T_number> aAxis)
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicAlong(const UnitVec<2, T_number> aAxis)
     {
         return scale(T_number{0}, aAxis);
     }
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> reflectAlongX()
+    constexpr LinearMatrix<2, 2, T_number> reflectAlongX()
     {
         return scale(T_number{-1}, T_number{1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> reflectAlongY()
+    constexpr LinearMatrix<2, 2, T_number> reflectAlongY()
     {
         return scale(T_number{1}, T_number{-1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> reflectAlong(const UnitVec<2, T_number> aAxis)
+    constexpr LinearMatrix<2, 2, T_number> reflectAlong(const UnitVec<2, T_number> aAxis)
     {
         return scale(T_number{-1}, aAxis);
     }
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> shearX(const T_number aWeightY)
+    constexpr LinearMatrix<2, 2, T_number> shearX(const T_number aWeightY)
     {
         return {
             T_number{1},    T_number{0},
@@ -113,7 +113,7 @@ namespace trans2d {
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> shearY(const T_number aWeightX)
+    constexpr LinearMatrix<2, 2, T_number> shearY(const T_number aWeightX)
     {
         return {
             T_number{1},       aWeightX,
@@ -123,7 +123,7 @@ namespace trans2d {
 
 
     template <class T_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     shearVertical(const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise)
     {
         return shearX(-tan(aCounterClockwise));
@@ -131,7 +131,7 @@ namespace trans2d {
 
 
     template <class T_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     shearHorizontal(const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise)
     {
         return shearY(tan(aCounterClockwise));
@@ -239,7 +239,7 @@ namespace trans3d {
 
 
     template <class T_number, class T_angleUnitTag>
-    constexpr Matrix<3, 3, T_number> rotateX(const Angle<T_number, T_angleUnitTag> aAngle)
+    constexpr LinearMatrix<3, 3, T_number> rotateX(const Angle<T_number, T_angleUnitTag> aAngle)
     {
         return {
             T_number{1.}, T_number{0.},  T_number{0.},
@@ -250,7 +250,7 @@ namespace trans3d {
 
 
     template <class T_number, class T_angleUnitTag>
-    constexpr Matrix<3, 3, T_number> rotateY(const Angle<T_number, T_angleUnitTag> aAngle)
+    constexpr LinearMatrix<3, 3, T_number> rotateY(const Angle<T_number, T_angleUnitTag> aAngle)
     {
         return {
             cos(aAngle),    T_number{0.}, -sin(aAngle),
@@ -261,7 +261,7 @@ namespace trans3d {
 
 
     template <class T_number, class T_angleUnitTag>
-    constexpr Matrix<3, 3, T_number> rotateZ(const Angle<T_number, T_angleUnitTag> aAngle)
+    constexpr LinearMatrix<3, 3, T_number> rotateZ(const Angle<T_number, T_angleUnitTag> aAngle)
     {
         return {
              cos(aAngle),   sin(aAngle),    T_number{0.},
@@ -272,7 +272,7 @@ namespace trans3d {
 
 
     template <class T_number, class T_angleUnitTag>
-    constexpr Matrix<3, 3, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle,
+    constexpr LinearMatrix<3, 3, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle,
                                             const UnitVec<3, T_number> aAxis)
     {
         // Some compact aliases for parameters
@@ -288,7 +288,7 @@ namespace trans3d {
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> scale(const T_number aFactorX,
+    constexpr LinearMatrix<3, 3, T_number> scale(const T_number aFactorX,
                                            const T_number aFactorY,
                                            const T_number aFactorZ)
     {
@@ -302,7 +302,7 @@ namespace trans3d {
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> scale(const T_number aFactor, const UnitVec<3, T_number> aAxis)
+    constexpr LinearMatrix<3, 3, T_number> scale(const T_number aFactor, const UnitVec<3, T_number> aAxis)
     {
         // Some compact aliases for parameters
         const T_number & k = aFactor;
@@ -317,63 +317,63 @@ namespace trans3d {
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoXY()
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoXY()
     {
         return scale(T_number{1}, T_number{1}, T_number{0});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoXZ()
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoXZ()
     {
         return scale(T_number{1}, T_number{0}, T_number{1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoYZ()
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoYZ()
     {
         return scale(T_number{0}, T_number{1}, T_number{1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicAlong(const UnitVec<3, T_number> aAxis)
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicAlong(const UnitVec<3, T_number> aAxis)
     {
         return scale(T_number{0}, aAxis);
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongX()
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongX()
     {
         return scale(T_number{-1}, T_number{1}, T_number{1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongY()
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongY()
     {
         return scale(T_number{1}, T_number{-1}, T_number{1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongZ()
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongZ()
     {
         return scale(T_number{1}, T_number{1}, T_number{-1});
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> reflectAlong(const UnitVec<3, T_number> aAxis)
+    constexpr LinearMatrix<3, 3, T_number> reflectAlong(const UnitVec<3, T_number> aAxis)
     {
         return scale(T_number{-1}, aAxis);
     }
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearXY(const T_number aWeightZonX,
+    constexpr LinearMatrix<3, 3, T_number> shearXY(const T_number aWeightZonX,
                                              const T_number aWeightZonY)
     {
         return {
@@ -385,7 +385,7 @@ namespace trans3d {
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearXZ(const T_number aWeightYonX,
+    constexpr LinearMatrix<3, 3, T_number> shearXZ(const T_number aWeightYonX,
                                              const T_number aWeightYonZ)
     {
         return {
@@ -397,7 +397,7 @@ namespace trans3d {
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearYZ(const T_number aWeightXonY,
+    constexpr LinearMatrix<3, 3, T_number> shearYZ(const T_number aWeightXonY,
                                              const T_number aWeightXonZ)
     {
         return {

--- a/src/libs/math/math/Transformations-impl.h
+++ b/src/libs/math/math/Transformations-impl.h
@@ -15,6 +15,16 @@ namespace trans2d {
     }
 
 
+    template <class T_number, class T_angleUnitTag>
+    constexpr AffineMatrix<3, T_number> rotateAbout(const Angle<T_number, T_angleUnitTag> aAngle,
+                                                    const Position<2, T_number> aRotationCenter)
+    {
+        return translate(-aRotationCenter.template as<Vec>()) 
+            * rotate(aAngle) 
+            * translate(aRotationCenter.template as<Vec>());
+    }
+
+
     template <class T_number>
     constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY)
     {

--- a/src/libs/math/math/Transformations.h
+++ b/src/libs/math/math/Transformations.h
@@ -23,6 +23,9 @@ namespace trans2d {
     template <class T_number, class T_angleUnitTag=void>
     constexpr LinearMatrix<2, 2, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle);
 
+    template <class T_number, class T_angleUnitTag=void>
+    constexpr AffineMatrix<3, T_number> rotateAbout(const Angle<T_number, T_angleUnitTag> aAngle,
+                                                    const Position<2, T_number> aRotationCenter);
 
     template <class T_number>
     constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY);

--- a/src/libs/math/math/Transformations.h
+++ b/src/libs/math/math/Transformations.h
@@ -6,7 +6,7 @@
 #include "Base.h"
 #include "Box.h"
 #include "Homogeneous.h"
-#include "Matrix.h"
+#include "LinearMatrix.h"
 #include "Rectangle.h"
 #include "Vector.h"
 
@@ -21,14 +21,14 @@ namespace trans2d {
 
     /// \brief Counter-clockwise rotation.
     template <class T_number, class T_angleUnitTag=void>
-    constexpr Matrix<2, 2, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle);
+    constexpr LinearMatrix<2, 2, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle);
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY);
+    constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactorX, const T_number aFactorY);
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> scale(const T_number aFactor, const UnitVec<2, T_number> aAxis);
+    constexpr LinearMatrix<2, 2, T_number> scale(const T_number aFactor, const UnitVec<2, T_number> aAxis);
 
 
     /// \brief Non-uniform non-axis-aligned scale.
@@ -37,51 +37,51 @@ namespace trans2d {
     ///
     /// \note see: FoCG 3rd p122
     template <class T_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     scale(const T_number aFactorHorizontal, const T_number aFactorVertical,
           const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise);
 
 
     /// \brief Projects \b onto X
     template <class T_number=real_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicOntoX();
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicOntoX();
 
     /// \brief Projects \b onto Y
     template <class T_number=real_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicOntoY();
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicOntoY();
 
     /// \brief Projects \b along aAxis, \b onto the line perpendicular to axis
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> projectOrthographicAlong(const UnitVec<2, T_number> aAxis);
+    constexpr LinearMatrix<2, 2, T_number> projectOrthographicAlong(const UnitVec<2, T_number> aAxis);
 
 
     /// \brief Reflects \b along X
     template <class T_number=real_number>
-    constexpr Matrix<2, 2, T_number> reflectAlongX();
+    constexpr LinearMatrix<2, 2, T_number> reflectAlongX();
 
     /// \brief Reflects \b along Y
     template <class T_number=real_number>
-    constexpr Matrix<2, 2, T_number> reflectAlongY();
+    constexpr LinearMatrix<2, 2, T_number> reflectAlongY();
 
     /// \brief Reflects \b along aAxis
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> reflectAlong(const UnitVec<2, T_number> aAxis);
+    constexpr LinearMatrix<2, 2, T_number> reflectAlong(const UnitVec<2, T_number> aAxis);
 
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> shearX(const T_number aWeightY);
+    constexpr LinearMatrix<2, 2, T_number> shearX(const T_number aWeightY);
 
     template <class T_number>
-    constexpr Matrix<2, 2, T_number> shearY(const T_number aWeightX);
+    constexpr LinearMatrix<2, 2, T_number> shearY(const T_number aWeightX);
 
     /// \brief Shear matrix that tilts the vertical axis counter-clockwise (shears the X axis).
     template <class T_number=real_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     shearVertical(const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise);
 
     /// \brief Shear matrix that tilts the horizontal axis counter-clockwise (shear the Y axis).
     template <class T_number=real_number, class T_angleRepresentation, class T_angleUnitTag>
-    constexpr Matrix<2, 2, T_number>
+    constexpr LinearMatrix<2, 2, T_number>
     shearHorizontal(const Angle<T_angleRepresentation, T_angleUnitTag> aCounterClockwise);
 
 
@@ -124,73 +124,73 @@ namespace trans3d {
 
 
     template <class T_number, class T_angleUnitTag=void>
-    constexpr Matrix<3, 3, T_number> rotateX(const Angle<T_number, T_angleUnitTag> aAngle);
+    constexpr LinearMatrix<3, 3, T_number> rotateX(const Angle<T_number, T_angleUnitTag> aAngle);
 
     template <class T_number, class T_angleUnitTag=void>
-    constexpr Matrix<3, 3, T_number> rotateY(const Angle<T_number, T_angleUnitTag> aAngle);
+    constexpr LinearMatrix<3, 3, T_number> rotateY(const Angle<T_number, T_angleUnitTag> aAngle);
 
     template <class T_number, class T_angleUnitTag=void>
-    constexpr Matrix<3, 3, T_number> rotateZ(const Angle<T_number, T_angleUnitTag> aAngle);
+    constexpr LinearMatrix<3, 3, T_number> rotateZ(const Angle<T_number, T_angleUnitTag> aAngle);
 
     template <class T_number, class T_angleUnitTag=void>
-    constexpr Matrix<3, 3, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle,
-                                            const UnitVec<3, T_number> aAxis);
+    constexpr LinearMatrix<3, 3, T_number> rotate(const Angle<T_number, T_angleUnitTag> aAngle,
+                                                  const UnitVec<3, T_number> aAxis);
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> scale(const T_number aFactorX,
-                                           const T_number aFactorY,
-                                           const T_number aFactorZ);
+    constexpr LinearMatrix<3, 3, T_number> scale(const T_number aFactorX,
+                                                 const T_number aFactorY,
+                                                 const T_number aFactorZ);
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> scale(const T_number aFactor, const UnitVec<3, T_number> aAxis);
+    constexpr LinearMatrix<3, 3, T_number> scale(const T_number aFactor, const UnitVec<3, T_number> aAxis);
 
 
     /// \brief Projects \b onto XY plane
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoXY();
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoXY();
 
     /// \brief Projects \b onto XZ plane
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoXZ();
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoXZ();
 
     /// \brief Projects \b onto YZ plane
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicOntoYZ();
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicOntoYZ();
 
     /// \brief Projects \b along aAxis, onto the plane perpendicular to it
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> projectOrthographicAlong(const UnitVec<3, T_number> aAxis);
+    constexpr LinearMatrix<3, 3, T_number> projectOrthographicAlong(const UnitVec<3, T_number> aAxis);
 
 
     /// \brief Reflects \b along X
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongX();
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongX();
 
     /// \brief Reflects \b along Y
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongY();
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongY();
 
     /// \brief Reflects \b along Z
     template <class T_number=real_number>
-    constexpr Matrix<3, 3, T_number> reflectAlongZ();
+    constexpr LinearMatrix<3, 3, T_number> reflectAlongZ();
 
     /// \brief Reflects \b along aAxis
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> reflectAlong(const UnitVec<3, T_number> aAxis);
+    constexpr LinearMatrix<3, 3, T_number> reflectAlong(const UnitVec<3, T_number> aAxis);
 
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearXY(const T_number aWeightZonX,
-                                             const T_number aWeightZonY);
+    constexpr LinearMatrix<3, 3, T_number> shearXY(const T_number aWeightZonX,
+                                                   const T_number aWeightZonY);
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearXZ(const T_number aWeightYonX,
-                                             const T_number aWeightYonZ);
+    constexpr LinearMatrix<3, 3, T_number> shearXZ(const T_number aWeightYonX,
+                                                   const T_number aWeightYonZ);
 
     template <class T_number>
-    constexpr Matrix<3, 3, T_number> shearYZ(const T_number aWeightXonY,
-                                             const T_number aWeightXonZ);
+    constexpr LinearMatrix<3, 3, T_number> shearYZ(const T_number aWeightXonY,
+                                                   const T_number aWeightXonZ);
 
 
     template <class T_number>


### PR DESCRIPTION
- More tests covering AffineMatrix conversions, ctor from N-1 explicit.
- Start implementing a LinearMatrix specialized Matrix class.
- Extend LinearMatrix with Identity ctor and more testing.
- Return LinearMatrix instead of Matrix in Transorfomations.
- Fix AffineMatrix conversion and multiplication behaviours. Now can be constructed from LinearMatrix of dimensions N-1.
- Implement 2D rotation about an arbitrary rotation center.
